### PR TITLE
Support for gulp 4 tasks and fixed task order

### DIFF
--- a/Gulp/Gulp.psm1
+++ b/Gulp/Gulp.psm1
@@ -1,4 +1,4 @@
-$script:taskDeps = @{}
+$script:taskDeps = [ordered]@{}
 $script:taskBlocks = New-Object -TypeName PSObject
 
 function Add-Task {

--- a/index.js
+++ b/index.js
@@ -63,7 +63,11 @@ module.exports = function (gulp, file) {
 
             taskProcess.on('close', () => cb());
          };
-         gulp.task(key, tasks[key], cb);
+
+         const dependencyTasks = tasks[key];
+
+         if (dependencyTasks.length) gulp.task(key, gulp.series(dependencyTasks), cb);
+         else gulp.task(key, cb);
       });
    }
 };


### PR DESCRIPTION
Gulp 4 doesn't support array dependency tasks so replaced the relevant code with the new `gulp.series()`.
Also made the internal powershell task hashtable ordered, as gulp 4 is picky about the order and would throw an error when a task depends on an yet undefined task.