### PR TITLE
Gulp 4 task only accepts 2 arguments, kids

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,8 +66,7 @@ module.exports = function (gulp, file) {
 
          const dependencyTasks = tasks[key];
 
-         if (dependencyTasks.length) gulp.task(key, gulp.series(dependencyTasks), cb);
-         else gulp.task(key, cb);
+         gulp.task(key, gulp.series(dependencyTasks, cb));
       });
    }
 };


### PR DESCRIPTION
I've discovered that the task action when there are dependencies is not executed and found that it's due to `gulp.task` only accepting 2 arguments now: task name and the function. The latter can be a result of `gulp.series`/`gulp.parallel`.