### PR TITLE
Filter exception rows from the output and add name to the powershell gulp task

### DIFF
--- a/Gulp/Gulp.psm1
+++ b/Gulp/Gulp.psm1
@@ -4,7 +4,7 @@ $script:taskArgs = [ordered]@{}
 function Add-Task {
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [string]
         $name,
         [string[]]
@@ -18,63 +18,68 @@ function Add-Task {
         $script:taskDeps[$name] = $deps
         $script:taskArgs[$name] = $arguments
         $script:taskBlocks |
-            Add-Member `
-                -MemberType ScriptMethod `
-                -Name $name `
-                -Value $action `
-                -Force
+        Add-Member `
+            -MemberType ScriptMethod `
+            -Name $name `
+            -Value $action `
+            -Force
     }
 }
 
-function Export-Tasks(){
+function Export-Tasks() {
     $script:taskDeps | ConvertTo-Json -Compress
 }
 
-function Invoke-Task($name){
+function Invoke-Task($name) {
     $originalVerbosePreference = $global:VerbosePreference
     $originalDebugPreference = $global:DebugPreference
     try {
         $global:VerbosePreference = "Continue"
         $global:DebugPreference = "Continue"
         $result = ((Invoke-Command -Verbose $script:taskBlocks.$name.Script -ArgumentList $script:taskArgs.$name) *>&1)
-    } finally {
+    }
+    finally {
         $global:VerbosePreference = $originalVerbosePreference
         $global:DebugPreference = $originalDebugPreference
     }
-         
+
     $result | ForEach-Object {
-       $record = $_
-       switch ($record.GetType().Name)
-       {
-          "InformationRecord" { @{level = "information"; message = "$record".Trim()}  }
-          "String" { @{level = "unknown"; message = "$record".Trim()}  }
-          "WarningRecord" { @{level = "warning"; message = "$record".Trim()} }
-          "ErrorRecord" { @{level = "error"; message = "$record".Trim()}  }
-          "VerboseRecord" { @{level = "verbose"; message = "$record".Trim()}  }
-          "DebugRecord" { @{level = "debug"; message = "$record".Trim()}  }
-          default {
-             @{
-                level = "unknown"
-                message = ($record | Format-Table -HideTableHeaders -AutoSize -Wrap:$false | Out-String).Trim()
-             }
-          }
-       }
+        $record = $_
+        switch ($record.GetType().Name) {
+            "InformationRecord" { @{level = "information"; message = "$record".Trim() } }
+            "String" { @{level = "unknown"; message = "$record".Trim() } }
+            "WarningRecord" { @{level = "warning"; message = "$record".Trim() } }
+            "ErrorRecord" {
+                $message = $record.Exception.Message.Trim()
+                if ($message -eq "") { return }
+                @{level = "error"; message = $message }
+            }
+            "VerboseRecord" { @{level = "verbose"; message = "$record".Trim() } }
+            "DebugRecord" { @{level = "debug"; message = "$record".Trim() } }
+            default {
+                @{
+                    level   = "unknown"
+                    message = ($record | Format-Table -HideTableHeaders -AutoSize -Wrap:$false | Out-String).Trim()
+                }
+            }
+        }
     } | ForEach-Object {
-       ConvertTo-Json $_ -Compress
+        ConvertTo-Json $_ -Compress
     }
 }
 
-function Publish-Tasks{
+function Publish-Tasks {
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [AllowEmptyCollection()]
         [string[]] $execute
     )
     process {
         if ($execute) {
             Invoke-Task $execute[0]
-        } else {
+        }
+        else {
             Export-Tasks
         }
     }

--- a/Gulp/Gulp.tests.ps1
+++ b/Gulp/Gulp.tests.ps1
@@ -13,7 +13,7 @@ Describe "Publish-Tasks @()" {
             $result = Publish-Tasks @()
         }
         It "should have output of {}" {
-            $result | Should Be "{}"
+            $result | Should -Be "{}"
         }
     }
 
@@ -23,7 +23,7 @@ Describe "Publish-Tasks @()" {
             $result = Publish-Tasks @()
         }
         It "published should be {""empty"":[]]}" {
-            $result | Should Be "{""empty"":[]}"
+            $result | Should -Be "{""empty"":[]}"
         }
     }
 
@@ -35,7 +35,7 @@ Describe "Publish-Tasks @()" {
             $result = Publish-Tasks @()
         }
         It 'result should be {"one":[],"three":[],"two":[]}' {
-            $result | Should Be  '{"one":[],"three":[],"two":[]}'
+            $result | Should -Be  '{"one":[],"three":[],"two":[]}'
         }
     }
 }
@@ -56,7 +56,7 @@ Describe "Publish-Tasks 'name'" {
             $result = Publish-Tasks 'name'
         }
         It "named on publish should output 'test output arg0'" {
-            $result | Should Match """test output arg0"""
+            $result | Should -Match """test output arg0"""
         }
     }
 
@@ -66,7 +66,7 @@ Describe "Publish-Tasks 'name'" {
             $result = Publish-Tasks 'name'
         }
         It "named on publish should output 'test output arg1'" {
-            $result | Should Match """test output arg1"""
+            $result | Should -Match """test output arg1"""
         }
     }
 
@@ -76,7 +76,7 @@ Describe "Publish-Tasks 'name'" {
             $result = Publish-Tasks 'name'
         }
         It "named on publish should output 'test output'" {
-            $result | Should Match """test output"""
+            $result | Should -Match """test output"""
         }
     }
     Context "'name' is empty task" {
@@ -85,7 +85,7 @@ Describe "Publish-Tasks 'name'" {
             $result = Publish-Tasks 'name'
         }
         It "should have no output" {
-            $result | Should BeLike ""
+            $result | Should -BeLike ""
         }
     }
     Context "'name' prints `$PSScriptRoot" {
@@ -96,7 +96,7 @@ Describe "Publish-Tasks 'name'" {
             $result = Publish-Tasks 'name'
         }
         It "result should be like ""*\Gulp""" {
-            ($result | ConvertFrom-Json).Message | Should BeLike "*\Gulp"
+            ($result | ConvertFrom-Json).Message | Should -BeLike "*\Gulp"
         }
     }
     Context "'name' writes 'fail' error" {
@@ -111,13 +111,13 @@ Describe "Publish-Tasks 'name'" {
             ) > $null) 3>&1
         }
         It "result should be 'fail'" {
-            $result | Should Match """fail"""
+            $result | Should -Match """fail"""
         }
         It "error stream should be null" {
-            $errors | Should Be $null
+            $errors | Should -Be $null
         }
         It "warning stream should be null" {
-            $warnings | Should Be $null
+            $warnings | Should -Be $null
         }
     }
     Context "'name' writes 'careful!' warning" {
@@ -132,16 +132,16 @@ Describe "Publish-Tasks 'name'" {
             ) > $null) 3>&1
         }
         It 'result message should be "careful!"' {
-           ($result | ConvertFrom-Json).Message | Should Be "careful!"
+           ($result | ConvertFrom-Json).Message | Should -Be "careful!"
         }
         It 'result level should be "warning"' {
-           ($result | ConvertFrom-Json).Level | Should Be "warning"
+           ($result | ConvertFrom-Json).Level | Should -Be "warning"
         }
         It "error stream should be null" {
-            $errors | Should Be $null
+            $errors | Should -Be $null
         }
         It "warning stream should be null" {
-            $warnings | Should Be $null
+            $warnings | Should -Be $null
         }
     }
 }

--- a/index.js
+++ b/index.js
@@ -25,11 +25,11 @@ module.exports = function (gulp, file) {
    else {
       const tasks = JSON.parse(result.stdout);
       Object.keys(tasks).forEach(function (key) {
-         gulp.task(key, gulp.series(tasks[key], () => {
+         const task = () => {
             const execSwitches = switches.concat(file, key, process.argv);
             const taskProcess = spawn('powershell', execSwitches, { stdio: ['inherit', 'pipe'] });
-
             const taskLabel = colors.cyan(key);
+            const debugOrVerbose = (args.debug || args.verbose);
 
             taskProcess.stdout.on('data', data => {
                data
@@ -41,7 +41,7 @@ module.exports = function (gulp, file) {
                      switch (l.level)
                      {
                         case 'debug':
-                           args.verbose && log.info(taskLabel, l.message);
+                           debugOrVerbose && log.info(taskLabel, l.message);
                            break;
                         case 'verbose':
                            args.verbose && log.info(taskLabel, l.message);
@@ -62,7 +62,10 @@ module.exports = function (gulp, file) {
             });
 
             return taskProcess;
-         }));
+         };
+
+         task.displayName = `${key} powershell task`;
+         gulp.task(key, gulp.series(tasks[key], task));
       });
    }
 };

--- a/tests/integration.tests.ps1
+++ b/tests/integration.tests.ps1
@@ -1,11 +1,16 @@
-Function Merge-Streams ($script){
+BeforeAll {
+   function Merge-Streams {
+      param (
+         $script
+      )
+
    (& $script 2>&1) |
-      ForEach-Object {$line = ''} {
+      ForEach-Object -Begin { $line = '' } -Process {
          # There are some inconsistencies in errors, some "lines" are split into multiple
          # error objects and some are not. This following hack attempts to clean things
          # by "joining" the split errors.
          if ($_ -is [System.Management.Automation.ErrorRecord]) {
-            if ($_.TargetObject -eq $null) {
+            if ($null -eq $_.TargetObject) {
                $line += $_.Exception.Message
                if ($_.Exception.Message[$_.Exception.Message.Length - 1] -ne 10) {
                   return
@@ -24,6 +29,7 @@ Function Merge-Streams ($script){
 
          $line = ''
       }
+   }
 }
 
 Describe "Running tasks from gulp" {
@@ -31,59 +37,53 @@ Describe "Running tasks from gulp" {
    Context "Run 'posh:write:all'" {
       BeforeAll {
          Push-Location $PSScriptRoot
-         $result = Merge-Streams {npx gulp posh:write:all}
+         $script:result = Merge-Streams { npx gulp posh:write:all }
       }
       AfterAll {
          Pop-Location
       }
 
-      @(
-         "* Importing Tasks *"
-         "*"
-         "*"
-         "*"
-         "* simple write-host"
-         "* simple write-output"
-         "* simple write-error"
-         "* simple write-warning"
-         "* simple write-information"
-      ) | ForEach-Object { $i = 0; $line = '' } {
-
-         It "line $i is like '$_'" {
-            $result[$i] | Should BeLike $_
-         }
-
-         $i++
+      It "Line <line> is like <expected>" -TestCases @(
+         @{ Line = 0; Expected = "* Importing Tasks *" }
+         @{ Line = 1; Expected = "*" }
+         @{ Line = 2; Expected = "*" }
+         @{ Line = 3; Expected = "*" }
+         @{ Line = 4; Expected = "* simple write-host" }
+         @{ Line = 5; Expected = "* simple write-output" }
+         @{ Line = 6; Expected = "* simple write-error" }
+         @{ Line = 7; Expected = "* simple write-warning" }
+         @{ Line = 8; Expected = "* simple write-information" }
+      ) {
+         $script:result[$line] | Should -BeLike $expected
       }
+
    }
 
    Context "Run 'posh:write:all' with verbose" {
       BeforeAll {
          Push-Location $PSScriptRoot
-         $result = Merge-Streams {npx gulp posh:write:all --verbose}
+         $script:result = Merge-Streams { npx gulp posh:write:all --verbose }
       }
       AfterAll {
          Pop-Location
       }
 
-      @(
-         "* Importing Tasks *"
-         "*"
-         "*"
-         "*"
-         "* simple write-host"
-         "* simple write-output"
-         "* simple write-error"
-         "* simple write-warning"
-         "* simple write-information"
-         "* simple write-verbose"
-         "* simple write-debug"
-      ) | ForEach-Object { $i = 0 } {
-         It "line $i is like '$_'" {
-            $result[$i] | Should BeLike $_
-         }
-         $i++
+      It "Line <line> is like <expected>" -TestCases @(
+         @{ Line = 0; Expected = "* Importing Tasks *" }
+         @{ Line = 1; Expected = "*" }
+         @{ Line = 2; Expected = "*" }
+         @{ Line = 3; Expected = "*" }
+         @{ Line = 4; Expected = "* simple write-host" }
+         @{ Line = 5; Expected = "* simple write-output" }
+         @{ Line = 6; Expected = "* simple write-error" }
+         @{ Line = 7; Expected = "* simple write-warning" }
+         @{ Line = 8; Expected = "* simple write-information" }
+         @{ Line = 9; Expected = "* simple write-verbose" }
+         @{ Line = 10; Expected = "* simple write-debug" }
+      ) {
+         $script:result[$line] | Should -BeLike $expected
       }
+
    }
 
 }


### PR DESCRIPTION
In some cases, a command within a gulp task would output errors, which would also be accompanied by a `System.Management.Automation.RemoteException` (with an underlying catch-all `System.Management.Automation.ParentContainsErrorRecordException`), even when the command ran successfully. An example is running `docker-compose up --detach` within a gulp task registered with `posh-gulp`, which is misleading.

The change in this PR adds some logic to the `ErrorRecord` mapping of the task output, using `$_.Exception.Message` as opposed to simply `$_.ToString()` and skips the iteration if this trimmed value is empty, resulting in a cleaner output.

Another change in the PR is adding a name to the powershell part of the gulp task, to prevent logs like `Starting '<anonymous>'`. This will now be `Starting '<task name> powershell task'`.

Unit tests have been updated for Pester 5.