### PR TITLE
Fix pwsh command check and error handling

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -19,8 +19,8 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - run: npm ci
     - name: pester
-      uses: Amadevus/pwsh-script@v2.0.3
-      with:
-        script: |
-          if (!(Get-Module -ListAvailable -Name Pester)) { Install-Module -Name Pester -Scope CurrentUser }
-          Invoke-Pester
+      run: |
+        Set-PSRepository psgallery -InstallationPolicy trusted
+        Install-Module -Name Pester -RequiredVersion 5.5.0 -Confirm:$false -Force
+        Invoke-Pester
+      shell: pwsh

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [20.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -22,5 +22,5 @@ jobs:
       uses: Amadevus/pwsh-script@v2.0.3
       with:
         script: |
-          Install-Module -Name Pester -Force
-          Invoke-Pester -EnableExit
+          if (!(Get-Module -ListAvailable -Name Pester)) { Install-Module -Name Pester -Scope CurrentUser }
+          Invoke-Pester

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -18,5 +18,9 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm ci
-    - run: npm run build --if-present
-    - run: npm test
+    - name: pester
+      uses: Amadevus/pwsh-script@v2.0.3
+      with:
+        script: |
+          Install-Module -Name Pester -Force
+          Invoke-Pester -EnableExit

--- a/Gulp/Gulp.tests.ps1
+++ b/Gulp/Gulp.tests.ps1
@@ -95,8 +95,8 @@ Describe "Publish-Tasks 'name'" {
             }
             $result = Publish-Tasks 'name'
         }
-        It "result should be like ""*\Gulp""" {
-            ($result | ConvertFrom-Json).Message | Should -BeLike "*\Gulp"
+        It "result should be like ""*\Gulp"" or ""*/Gulp""" {
+            ($result | ConvertFrom-Json).Message | Should -Match "[*\\/]*Gulp"
         }
     }
     Context "'name' writes 'fail' error" {
@@ -111,7 +111,7 @@ Describe "Publish-Tasks 'name'" {
             ) > $null) 3>&1
         }
         It "result should be 'fail'" {
-            $result | Should -Match """fail"""
+            $result | Should -Match "fail"
         }
         It "error stream should be null" {
             $errors | Should -Be $null

--- a/Gulp/Gulp.tests.ps1
+++ b/Gulp/Gulp.tests.ps1
@@ -102,11 +102,7 @@ Describe "Publish-Tasks 'name'" {
     Context "'name' writes 'fail' error" {
         BeforeEach {
             Add-Task "name" @() {
-                try {
-                    Write-Error 'fail'
-                }
-                catch {
-                }
+                Write-Error 'fail'
             }
             $warnings = $((
                 $errors = $((

--- a/Gulp/Gulp.tests.ps1
+++ b/Gulp/Gulp.tests.ps1
@@ -101,6 +101,7 @@ Describe "Publish-Tasks 'name'" {
     }
     Context "'name' writes 'fail' error" {
         BeforeEach {
+            $ErrorActionPreference = 'Continue'
             Add-Task "name" @() {
                 Write-Error 'fail'
             }

--- a/Gulp/Gulp.tests.ps1
+++ b/Gulp/Gulp.tests.ps1
@@ -102,7 +102,11 @@ Describe "Publish-Tasks 'name'" {
     Context "'name' writes 'fail' error" {
         BeforeEach {
             Add-Task "name" @() {
-                Write-Error 'fail'
+                try {
+                    Write-Error 'fail'
+                }
+                catch {
+                }
             }
             $warnings = $((
                 $errors = $((

--- a/Gulp/Gulp.tests.ps1
+++ b/Gulp/Gulp.tests.ps1
@@ -115,7 +115,7 @@ Describe "Publish-Tasks 'name'" {
             ) > $null) 3>&1
         }
         It "result should be 'fail'" {
-            $result | Should -Match "fail"
+            ($result | ConvertFrom-Json).Message | Should -Be "fail"
         }
         It "error stream should be null" {
             $errors | Should -Be $null

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "posh-gulp",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "posh-gulp",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "license": "ISC",
       "dependencies": {
         "ansi-colors": "^4.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posh-gulp",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "write gulp tasks in powershell",
   "keywords": [
     "powershell",


### PR DESCRIPTION
Improving the error handling for powershell command execution.
Also it was deiscovered that `log.warn` doesn't produce any log when processing the stdout of the executed command, so replacing it with `log.info` as a workaround.