### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ const getPowershellCommand = (options) => {
   return pwshCommand;
 };
 
-module.exports = async function (gulp, file, options = { runOnWindowsPowershell: false }) {
+module.exports = function (gulp, file, options = { runOnWindowsPowershell: false }) {
    const powershellCommand = getPowershellCommand(options);
 
    if (!commandExists(powershellCommand)) {


### PR DESCRIPTION
In some cases the powershell script might output some warnings before returning the JSON containing the exported tasks. When this happens, the script will fail due to it not being able to parse the output. This change adds a try..catch around parsing and outputs the non-JSON string.